### PR TITLE
Canary

### DIFF
--- a/examples/next-lng-example/public/static/translations/en/header.json
+++ b/examples/next-lng-example/public/static/translations/en/header.json
@@ -1,0 +1,3 @@
+{
+	"title": "Header title"
+}

--- a/examples/next-lng-example/public/static/translations/fr/header.json
+++ b/examples/next-lng-example/public/static/translations/fr/header.json
@@ -1,0 +1,3 @@
+{
+	"title": "Titre de l'entête"
+}

--- a/examples/next-lng-example/src/pages/[lng]/example02.js
+++ b/examples/next-lng-example/src/pages/[lng]/example02.js
@@ -5,6 +5,7 @@ const Greet = () => {
 	// NB! the ids on dom elements are used only for testing purposes and can be safely deleted
 	return (
 		<>
+			<h1 id="x-header-title">{t("header.title")}</h1>
 			<p id="x-greet">{t("greet")}</p>
 			<p id="x-whoami">{t("whoami", { firstname: "Bob" })}</p>
 			<button onClick={() => setLng("en")}>EN</button>
@@ -21,7 +22,7 @@ const HomePage = () => {
 // Arguments:
 // [0] - a string or string[] of globs
 // [1] - an object that overrides the default `options` defined in next.config.js
-const getServerSideProps = getTranslations("*/common", { shallow: true });
+const getServerSideProps = getTranslations(["*/common", "header"], { shallow: true });
 export { getServerSideProps };
 
 export default withLng(HomePage);

--- a/packages/next-lng/src/getServerSideProps.js
+++ b/packages/next-lng/src/getServerSideProps.js
@@ -43,12 +43,13 @@ const getServerSideProps = async (ctx, files, options = defaultOptions) => {
 		body: JSON.stringify(body),
 		headers: { "Content-Type": "application/json" },
 	});
-	const translations = await data.json();
+	const { translations, translationsIncluded } = await data.json();
 
 	return {
 		props: {
 			lng,
 			translations,
+			translationsIncluded,
 			options,
 		},
 	};

--- a/packages/next-lng/src/withLng.js
+++ b/packages/next-lng/src/withLng.js
@@ -21,7 +21,7 @@ export const useLng = () => React.useContext(LngContext);
 
 const withLng = (ComposedComponent, options = {}) => {
 	const ComposedWithLng = (props) => {
-		const { lng: lngQuery, translations, options } = props;
+		const { lng: lngQuery, translations, translationsIncluded = [], options } = props;
 		const { shallow = true } = options;
 
 		const [lngState, setLngState] = React.useState(lngQuery);
@@ -58,8 +58,17 @@ const withLng = (ComposedComponent, options = {}) => {
 
 		// TRANSLATE FUNCTION
 		// ---
-		const t = (key, interpolations) => {
-			let translation = get(translations, `${lngState}.${key}`) || "";
+		const t = (key = "", interpolations) => {
+			const keyParts = key.split(".");
+			let filename = keyParts[0];
+			let translationKey = key;
+
+			// Not specifying the filename falls back to "common"
+			if (!translationsIncluded.includes(filename)) filename = "common";
+			else if (keyParts.length > 1) translationKey = keyParts.slice(1, keyParts.length).join(".");
+
+			const tp = `${lngState}.${filename}.${translationKey}`;
+			let translation = get(translations, tp) || "";
 
 			// TRANSLATION STRING INTERPOLATION
 			// ---

--- a/packages/next-lng/test/01_middleware.spec.js
+++ b/packages/next-lng/test/01_middleware.spec.js
@@ -20,9 +20,19 @@ describe(`MIDDLEWARE`, () => {
 
 		it(`Should get translations from api routes`, async () => {
 			// Manually get translations and compare with the response from our middleware
-			const translationsPath = path.resolve(global.lngPath, lng, "common.json");
-			const translations = require(translationsPath);
-			res.body.should.deep.include({ [lng]: translations });
+			const good = {
+				translations: {
+					en: {
+						common: require(path.resolve(global.lngPath, "en/common.json")),
+					},
+					fr: {
+						common: require(path.resolve(global.lngPath, "fr/common.json")),
+					},
+				},
+				translationsIncluded: ["common"],
+			};
+
+			res.body.should.deep.equal(good);
 		});
 
 		after(async () => {


### PR DESCRIPTION
Enables to use scoped translations, meaning that they come from another file than `common.json` and don't collide with other translations.

Example:
```jsx
// Comes from header.json
<h1>{t("header.title")}</h1>

// Comes from common.json
<h1>{t("title")}</h1>

// Comes from common.json as well
<h1>{t("common.title")}</h1>
```